### PR TITLE
Add test to validate YAML

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,6 +1,6 @@
 language: node_js
 node_js:
-  - "5"
+  - "5.11"
 install:
   - npm install js-yaml
 script:

--- a/.travis.yml
+++ b/.travis.yml
@@ -3,5 +3,4 @@ node_js:
   - "5.11"
 install:
   - npm install js-yaml
-script:
-  - node -e "require('js-yaml').safeLoad(require('fs').readFileSync('abbreviations.yml', { encoding: 'utf8' }))"
+script: sh test.sh

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,0 +1,7 @@
+language: node_js
+node_js:
+  - "5"
+install:
+  - npm install js-yaml
+script:
+  - node -e "require('js-yaml').safeLoad(require('fs').readFileSync('abbreviations.yml', { encoding: 'utf8' }))"

--- a/abbreviations.yml
+++ b/abbreviations.yml
@@ -357,7 +357,7 @@ abbreviations:
     description: |
       The contractor and Government share the costs.
     cross_references:
-  
+
   COTR:
     longform: 'Contracting Officer''s Technical Representative'
     description: |

--- a/abbreviations.yml
+++ b/abbreviations.yml
@@ -358,12 +358,6 @@ abbreviations:
       The contractor and Government share the costs.
     cross_references:
 
-  COR:
-    longform: 'Contracting Officer''s Technical Representative'
-    description: |
-      An individual designated and authorized in writing by the contracting officer to perform specific  technical or administrative functions.
-    cross_references:
-
   COTS:
     longform: Commercially available off-the-shelf
     description: |

--- a/abbreviations.yml
+++ b/abbreviations.yml
@@ -357,6 +357,12 @@ abbreviations:
     description: |
       The contractor and Government share the costs.
     cross_references:
+  
+  COTR:
+    longform: 'Contracting Officer''s Technical Representative'
+    description: |
+      An individual designated and authorized in writing by the contracting officer to perform specific  technical or administrative functions.
+    cross_references:
 
   COTS:
     longform: Commercially available off-the-shelf

--- a/test.sh
+++ b/test.sh
@@ -1,0 +1,2 @@
+#!/bin/sh
+node -e "require('js-yaml').safeLoad(require('fs').readFileSync('abbreviations.yml', { encoding: 'utf8' }))"


### PR DESCRIPTION
COR was in the list twice, which was causing `js-yaml` to throw an exception.  Per the spec, YAML doesn't support duplicate keys.  The second one is supposed to be COTR (apparently?).

Also adds a simple test to validate the YAML.
